### PR TITLE
use activesupport inflector to constantize

### DIFF
--- a/lib/archiving/archive_table.rb
+++ b/lib/archiving/archive_table.rb
@@ -1,4 +1,5 @@
 require "active_support/concern"
+require "active_support/inflector"
 
 module Archiving
   module ArchiveTable
@@ -11,7 +12,7 @@ module Archiving
       attr_accessor :archive_table
 
       def has_archive_table
-        model = Object.const_get(name)
+        model = name.constantize
         @archive_model = model.const_set("Archive", Class.new(model))
         @archive_model.after_initialize do |record|
           record.readonly! unless record.new_record?


### PR DESCRIPTION
in ruby 1.9, `Object.const_get` fails on namespaced strings, e.g.

``` ruby
class Foo
 class Bar
 end end

Object.const_get "Foo::Bar"

=> >> Object.const_get "Foo::Bar" NameError: wrong constant name Foo::Bar
       from (irb):5:in `const_get'
       from (irb):5
       from /usr/local/bin/irb:12:in `<main>'
```
