### PR TITLE
archive_aged_records takes before callback

### DIFF
--- a/lib/archiving/archive_table.rb
+++ b/lib/archiving/archive_table.rb
@@ -62,6 +62,10 @@ module Archiving
         if archive # not on archive class
           records = nil
           while records.nil? || records.any?
+            if options[:before_callback]
+              options[:before_callback].call
+            end
+
             records = where(options[:where]).order(options[:order]).limit(options[:batch_size])
             transaction do
               records.each do |instance|

--- a/test/archive_table_test.rb
+++ b/test/archive_table_test.rb
@@ -131,6 +131,18 @@ class ArchiveTableTest < ActiveSupport::TestCase
     assert_nil Post::Archive.find_by_id p2.id
   end
 
+  test "archiving aged records with before callback" do
+    p1 = Post.create!(title: "Post 1", tag: "news")
+    p2 = Post.create!(title: "Post 2", tag: "misc")
+    before_called = false
+
+    Post.archive_aged_records(where: "tag = 'news'", before_callback: lambda {
+      before_called = true
+    })
+
+    assert_equal true, before_called
+  end
+
   test "archiving a specific record" do
     p1 = Post.create!(title: "Post 1", tag: "news")
     assert_difference "Post.count", -1 do


### PR DESCRIPTION
Add a `before_callback` which is to be called before each new batch of records are archived. This allows adding sleep intervals as to avoid overloading the system while archiving.
