### PR TITLE
Do not hardcode mysql2 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in archiving.gemspec
 gemspec
+
+gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    archiving (0.4.4)
+    archiving (0.6.0)
       activerecord (>= 4.2, <= 8.1)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -112,7 +111,7 @@ GEM
     minitest (5.25.4)
     minitest-focus (1.4.0)
       minitest (>= 4, < 6)
-    mysql2 (0.5.6)
+    mysql2 (0.5.5)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -192,6 +191,7 @@ PLATFORMS
 DEPENDENCIES
   archiving!
   minitest-focus
+  mysql2
   rails (>= 4.2, <= 8.1)
   rake
   rr

--- a/archiving.gemspec
+++ b/archiving.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "activerecord", ">= 4.2", "<= 8.1"
-  s.add_dependency "mysql2"
 
   s.add_development_dependency "rails", ">= 4.2", "<= 8.1"
   s.add_development_dependency "rake"

--- a/gemfiles/active_record-7.1.gemfile
+++ b/gemfiles/active_record-7.1.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.1.0'
+gem 'mysql2'
 
 gemspec path: '../'

--- a/gemfiles/active_record-7.2.gemfile
+++ b/gemfiles/active_record-7.2.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.2.0'
+gem 'mysql2'
 
 gemspec path: '../'

--- a/gemfiles/active_record-8.0.gemfile
+++ b/gemfiles/active_record-8.0.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 8.0.0'
+gem 'mysql2'
 
 gemspec path: '../'


### PR DESCRIPTION
Do not hardcode _mysql2_ dependency. Some people use _trilogy_ instead.